### PR TITLE
#38: Add support for SonarQube 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ SonarQube Version | Plugin Version
 7.4 - 7.7         | 1.0.2
 
 # Installation
-Either build the project or [download a compatible release version of the plugin JAR](https://github.com/mc1arke/sonarqube-community-branch-plugin/releases). Copy the plugin JAR file to the `extensions/plugins/` directory of your SonarQube instance and restart SonarQube.
+Either build the project or [download a compatible release version of the plugin JAR](https://github.com/mc1arke/sonarqube-community-branch-plugin/releases). Copy the plugin JAR file to the `extensions/plugins/` **and** the `lib/common/` directories of your SonarQube instance and restart SonarQube.
 
 # Features
 The plugin is intended to support the [features and parameters specified in the SonarQube documentation](https://docs.sonarqube.org/latest/branches/overview/), with the following caveats

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -33,18 +33,21 @@ import org.sonar.api.SonarQubeSide;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
 import org.sonar.core.config.PurgeConstants;
+import org.sonar.core.extension.CoreExtension;
 
 /**
  * @author Michael Clarke
  */
-public class CommunityBranchPlugin implements Plugin {
+public class CommunityBranchPlugin implements Plugin, CoreExtension {
 
     @Override
-    public void define(Context context) {
-        if (SonarQubeSide.SCANNER == context.getRuntime().getSonarQubeSide()) {
-            context.addExtensions(CommunityProjectBranchesLoader.class, CommunityProjectPullRequestsLoader.class,
-                                  CommunityBranchConfigurationLoader.class, CommunityBranchParamsValidator.class);
-        } else if (SonarQubeSide.COMPUTE_ENGINE == context.getRuntime().getSonarQubeSide()) {
+    public String getName() {
+        return "Community Branch Plugin";
+    }
+
+    @Override
+    public void load(CoreExtension.Context context) {
+        if (SonarQubeSide.COMPUTE_ENGINE == context.getRuntime().getSonarQubeSide()) {
             context.addExtensions(CommunityReportAnalysisComponentProvider.class, CommunityBranchEditionProvider.class);
         } else if (SonarQubeSide.SERVER == context.getRuntime().getSonarQubeSide()) {
             context.addExtensions(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class);
@@ -68,4 +71,11 @@ public class CommunityBranchPlugin implements Plugin {
 
     }
 
+    @Override
+    public void define(Plugin.Context context) {
+        if (SonarQubeSide.SCANNER == context.getRuntime().getSonarQubeSide()) {
+            context.addExtensions(CommunityProjectBranchesLoader.class, CommunityProjectPullRequestsLoader.class,
+                                  CommunityBranchConfigurationLoader.class, CommunityBranchParamsValidator.class);
+        }
+    }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginBootstrap.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginBootstrap.java
@@ -22,6 +22,7 @@ import com.github.mc1arke.sonarqube.plugin.classloader.DefaultElevatedClassLoade
 import com.github.mc1arke.sonarqube.plugin.classloader.ElevatedClassLoaderFactory;
 import com.github.mc1arke.sonarqube.plugin.classloader.ElevatedClassLoaderFactoryProvider;
 import org.sonar.api.Plugin;
+import org.sonar.api.SonarQubeSide;
 
 import java.util.Objects;
 
@@ -55,6 +56,9 @@ public class CommunityBranchPluginBootstrap implements Plugin {
 
     @Override
     public void define(Context context) {
+        if (SonarQubeSide.SCANNER != context.getRuntime().getSonarQubeSide()) {
+            return;
+        }
         try {
             ClassLoader classLoader =
                     elevatedClassLoaderFactoryProvider.createFactory(context).createClassLoader(getClass());

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranch.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranch.java
@@ -62,6 +62,7 @@ public class CommunityBranch implements Branch {
         return main;
     }
 
+    // Can be removed when support removed for SonarQube 7.9
     @Override
     public boolean isLegacyFeature() {
         return false;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchParamsValidator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchParamsValidator.java
@@ -36,6 +36,7 @@ public class CommunityBranchParamsValidator implements BranchParamsValidator {
         this.globalConfiguration = globalConfiguration;
     }
 
+    //Can be removed when support for SonarQube 7.9 is removed
     @Override
     public void validate(List<String> validationMessages, String deprecatedBranchName) {
         if (null != deprecatedBranchName && (globalConfiguration.hasKey(ScannerProperties.BRANCH_NAME) ||
@@ -44,5 +45,10 @@ public class CommunityBranchParamsValidator implements BranchParamsValidator {
                     "The legacy 'sonar.branch' parameter cannot be used at the same time as '%s' or '%s'",
                     ScannerProperties.BRANCH_NAME, ScannerProperties.BRANCH_TARGET));
         }
+    }
+
+    //@Override since SonarQube 8.0
+    public void validate(List<String> validationMessages) {
+        //no-op - nothing to validate
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityProjectPullRequestsLoader.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityProjectPullRequestsLoader.java
@@ -29,13 +29,14 @@ import org.sonar.scanner.bootstrap.ScannerWsClient;
 import org.sonar.scanner.scan.branch.ProjectPullRequests;
 import org.sonar.scanner.scan.branch.ProjectPullRequestsLoader;
 import org.sonar.scanner.scan.branch.PullRequestInfo;
-import org.sonar.scanner.util.ScannerUtils;
 import org.sonarqube.ws.client.GetRequest;
 import org.sonarqube.ws.client.HttpException;
 import org.sonarqube.ws.client.WsResponse;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -51,12 +52,12 @@ public class CommunityProjectPullRequestsLoader implements ProjectPullRequestsLo
     private static final Logger LOGGER = Loggers.get(CommunityProjectPullRequestsLoader.class);
     private static final String PROJECT_PULL_REQUESTS_URL = "/api/project_pull_requests/list?project=";
 
-    private final ScannerWsClient scannerWsClient;
+    private final ScannerWsClientWrapper scannerWsClient;
     private final Gson gson;
 
     public CommunityProjectPullRequestsLoader(ScannerWsClient scannerWsClient) {
         super();
-        this.scannerWsClient = scannerWsClient;
+        this.scannerWsClient = new ScannerWsClientWrapper(scannerWsClient);
         this.gson =
                 new GsonBuilder().registerTypeAdapter(PullRequestInfo.class, createPullRequestInfoJsonDeserialiser())
                         .create();
@@ -79,13 +80,16 @@ public class CommunityProjectPullRequestsLoader implements ProjectPullRequestsLo
 
     @Override
     public ProjectPullRequests load(String projectKey) {
-        GetRequest branchesGetRequest =
-                new GetRequest(PROJECT_PULL_REQUESTS_URL + ScannerUtils.encodeForUrl(projectKey));
+        try {
+            GetRequest branchesGetRequest = new GetRequest(
+                    PROJECT_PULL_REQUESTS_URL + URLEncoder.encode(projectKey, StandardCharsets.UTF_8.name()));
 
-        try (WsResponse branchesResponse = scannerWsClient.call(branchesGetRequest); Reader reader = branchesResponse
+            try (WsResponse branchesResponse = scannerWsClient
+                    .call(branchesGetRequest); Reader reader = branchesResponse
                 .contentReader()) {
-            PullRequestsResponse parsedResponse = gson.fromJson(reader, PullRequestsResponse.class);
-            return new ProjectPullRequests(parsedResponse.getPullRequests());
+                PullRequestsResponse parsedResponse = gson.fromJson(reader, PullRequestsResponse.class);
+                return new ProjectPullRequests(parsedResponse.getPullRequests());
+            }
         } catch (IOException e) {
             throw MessageException.of("Could not load pull requests from server", e);
         } catch (HttpException e) {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerWsClientWrapper.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerWsClientWrapper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner;
+
+import org.sonar.scanner.bootstrap.ScannerWsClient;
+import org.sonarqube.ws.client.WsRequest;
+import org.sonarqube.ws.client.WsResponse;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Provides a way of invoking {@link ScannerWsClient} between SonarQube versions where it changed from being a class
+ * to being an interface.
+ */
+// Can be removed when support for SonarQube < 8.0 is removed
+/*package*/ class ScannerWsClientWrapper {
+
+    private final Object wsClient;
+
+    /*package*/ ScannerWsClientWrapper(Object wsClient) {
+        this.wsClient = wsClient;
+    }
+
+    WsResponse call(WsRequest request) {
+        try {
+            return (WsResponse) wsClient.getClass().getMethod("call", WsRequest.class).invoke(wsClient, request);
+        } catch (ReflectiveOperationException ex) {
+            handleIfInvocationException(ex);
+            throw new IllegalStateException("Could not execute ScannerWsClient", ex);
+        }
+    }
+
+    private static void handleIfInvocationException(ReflectiveOperationException ex) {
+        if (!(ex instanceof InvocationTargetException)) {
+            return;
+        }
+        Throwable cause = ex.getCause();
+        if (cause instanceof Error) {
+            throw (Error) cause;
+        } else if (cause instanceof RuntimeException) {
+            throw (RuntimeException) cause;
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityComponentKey.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityComponentKey.java
@@ -52,6 +52,7 @@ import java.util.Optional;
         return dbKey;
     }
 
+    //Can be removed when Support for SonarQube 7.9 is removed
     @Override
     public Optional<String> getDeprecatedBranchName() {
         return Optional.ofNullable(deprecatedBranchName);

--- a/src/main/resources/META-INF/services/org.sonar.core.extension.CoreExtension
+++ b/src/main/resources/META-INF/services/org.sonar.core.extension.CoreExtension
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2019 Michael Clarke
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#
+#
+# Copyright (C) 2019 Michael Clarke
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#
+com.github.mc1arke.sonarqube.plugin.CommunityBranchPlugin

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -33,11 +33,14 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.sonar.api.Plugin;
 import org.sonar.api.SonarQubeSide;
+import org.sonar.core.extension.CoreExtension;
 
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -65,7 +68,7 @@ public class CommunityBranchPluginTest {
         testCase.define(context);
 
         ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
-        verify(context, times(2))
+        verify(context, times(1))
                 .addExtensions(argumentCaptor.capture(), argumentCaptor.capture(), argumentCaptor.capture());
 
 
@@ -75,26 +78,7 @@ public class CommunityBranchPluginTest {
     }
 
     @Test
-    public void testComputeEngineSideDefine() {
-        CommunityBranchPlugin testCase = new CommunityBranchPlugin();
-
-        Plugin.Context context = spy(mock(Plugin.Context.class, Mockito.RETURNS_DEEP_STUBS));
-        when(context.getRuntime().getSonarQubeSide()).thenReturn(SonarQubeSide.COMPUTE_ENGINE);
-
-        testCase.define(context);
-
-        ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
-        verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
-
-
-        assertEquals(
-                Arrays.asList(CommunityReportAnalysisComponentProvider.class, CommunityBranchEditionProvider.class),
-                argumentCaptor.getAllValues().subList(0, 2));
-    }
-
-
-    @Test
-    public void testServerSideDefine() {
+    public void testNonScannerSideDefine() {
         CommunityBranchPlugin testCase = new CommunityBranchPlugin();
 
         Plugin.Context context = spy(mock(Plugin.Context.class, Mockito.RETURNS_DEEP_STUBS));
@@ -102,9 +86,38 @@ public class CommunityBranchPluginTest {
 
         testCase.define(context);
 
+        verify(context, never()).addExtensions(any());
+    }
+
+    @Test
+    public void testComputeEngineSideLoad() {
+        CommunityBranchPlugin testCase = new CommunityBranchPlugin();
+
+        CoreExtension.Context context = spy(mock(CoreExtension.Context.class, Mockito.RETURNS_DEEP_STUBS));
+        when(context.getRuntime().getSonarQubeSide()).thenReturn(SonarQubeSide.COMPUTE_ENGINE);
+
+        testCase.load(context);
+
         ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
-        verify(context, times(2))
-                .addExtensions(argumentCaptor.capture(), argumentCaptor.capture(), argumentCaptor.capture());
+        verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
+
+
+        assertEquals(Arrays.asList(CommunityReportAnalysisComponentProvider.class, CommunityBranchEditionProvider.class),
+                     argumentCaptor.getAllValues().subList(0, 2));
+    }
+
+
+    @Test
+    public void testServerSideLoad() {
+        CommunityBranchPlugin testCase = new CommunityBranchPlugin();
+
+        CoreExtension.Context context = spy(mock(CoreExtension.Context.class, Mockito.RETURNS_DEEP_STUBS));
+        when(context.getRuntime().getSonarQubeSide()).thenReturn(SonarQubeSide.SERVER);
+
+        testCase.load(context);
+
+        ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
 
         assertEquals(Arrays.asList(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class),
@@ -112,17 +125,22 @@ public class CommunityBranchPluginTest {
     }
 
     @Test
-    public void testDefine() {
+    public void testLoad() {
         CommunityBranchPlugin testCase = new CommunityBranchPlugin();
 
-        Plugin.Context context = spy(mock(Plugin.Context.class, Mockito.RETURNS_DEEP_STUBS));
+        CoreExtension.Context context = spy(mock(CoreExtension.Context.class, Mockito.RETURNS_DEEP_STUBS));
 
-        testCase.define(context);
+        testCase.load(context);
 
         ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
-        verify(context).addExtensions(argumentCaptor.capture(), argumentCaptor.capture(), argumentCaptor.capture());
+        verify(context).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
 
         assertEquals(2, argumentCaptor.getAllValues().size());
+    }
+
+    @Test
+    public void testGetName() {
+        assertEquals("Community Branch Plugin", new CommunityBranchPlugin().getName());
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchParamsValidatorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchParamsValidatorTest.java
@@ -80,4 +80,15 @@ public class CommunityBranchParamsValidatorTest {
                 "The legacy 'sonar.branch' parameter cannot be used at the same time as 'sonar.branch.name' or 'sonar.branch.target'",
                 messages.get(0));
     }
+
+    @Test
+    public void testNoMessagesOnValidate() {
+        List<String> messages = new ArrayList<>();
+
+        GlobalConfiguration globalConfiguration = mock(GlobalConfiguration.class);
+        when(globalConfiguration.hasKey(eq("sonar.branch.target"))).thenReturn(true);
+        when(globalConfiguration.hasKey(eq("sonar.branch"))).thenReturn(true);
+        new CommunityBranchParamsValidator(globalConfiguration).validate(messages);
+        assertEquals(0, messages.size());
+    }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityProjectBranchesLoaderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityProjectBranchesLoaderTest.java
@@ -145,16 +145,7 @@ public class CommunityProjectBranchesLoaderTest {
 
     @Test
     public void testEmptyListOn404HttpResponse() {
-        WsResponse mockResponse = mock(WsResponse.class);
-        when(scannerWsClient.call(any())).thenReturn(mockResponse);
-
-        Reader mockReader = new BufferedReader(new StringReader(
-                GsonHelper.create().toJson(new CommunityProjectBranchesLoader.BranchesResponse(new ArrayList<>())))) {
-            public void close() {
-                throw new HttpException("url", 404, "content");
-            }
-        };
-        when(mockResponse.contentReader()).thenReturn(mockReader);
+        when(scannerWsClient.call(any())).thenThrow(new HttpException("url", 404, "content"));
 
         CommunityProjectBranchesLoader testCase = new CommunityProjectBranchesLoader(scannerWsClient);
         assertTrue(testCase.load("project").isEmpty());

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityProjectPullRequestsLoaderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityProjectPullRequestsLoaderTest.java
@@ -164,17 +164,7 @@ public class CommunityProjectPullRequestsLoaderTest {
 
     @Test
     public void testEmptyListOn404HttpResponse() {
-        WsResponse mockResponse = mock(WsResponse.class);
-        when(scannerWsClient.call(any())).thenReturn(mockResponse);
-
-        Reader mockReader = new BufferedReader(new StringReader(GsonHelper.create()
-                                                                        .toJson(new CommunityProjectPullRequestsLoader.PullRequestsResponse(
-                                                                                new ArrayList<>())))) {
-            public void close() {
-                throw new HttpException("url", 404, "content");
-            }
-        };
-        when(mockResponse.contentReader()).thenReturn(mockReader);
+        when(scannerWsClient.call(any())).thenThrow(new HttpException("url", 404, "content"));
 
         CommunityProjectPullRequestsLoader testCase = new CommunityProjectPullRequestsLoader(scannerWsClient);
         assertTrue(testCase.load("project").isEmpty());

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerWsClientWrapperTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerWsClientWrapperTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2019 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.core.IsEqual;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.sonar.scanner.bootstrap.ScannerWsClient;
+import org.sonarqube.ws.client.WsRequest;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+public class ScannerWsClientWrapperTest {
+
+    private final ExpectedException expectedException = ExpectedException.none();
+
+    @Rule
+    public ExpectedException expectedException() {
+        return expectedException;
+    }
+
+    @Test
+    public void testRuntimeExceptionPropagated() {
+        ScannerWsClient scannerWsClient = mock(ScannerWsClient.class);
+        doThrow(new IllegalStateException("Whoops")).when(scannerWsClient).call(any());
+
+        expectedException.expectMessage(IsEqual.equalTo("Whoops"));
+        expectedException.expect(IllegalStateException.class);
+
+        new ScannerWsClientWrapper(scannerWsClient).call(mock(WsRequest.class));
+    }
+
+    @Test
+    public void testErrorPropagated() {
+        ScannerWsClient scannerWsClient = mock(ScannerWsClient.class);
+        doThrow(new ClassFormatError("Whoops")).when(scannerWsClient).call(any());
+
+        expectedException.expectMessage(IsEqual.equalTo("Whoops"));
+        expectedException.expect(ClassFormatError.class);
+
+        new ScannerWsClientWrapper(scannerWsClient).call(mock(WsRequest.class));
+    }
+
+    @Test
+    public void testCheckedExceptionWrapped() {
+        ScannerWsClient scannerWsClient = mock(ScannerWsClient.class);
+        doAnswer(i -> {
+            throw new IOException("Whoops");
+        }).when(scannerWsClient).call(any());
+
+        expectedException.expectMessage(IsEqual.equalTo("Could not execute ScannerWsClient"));
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectCause(new BaseMatcher<Throwable>() {
+            @Override
+            public boolean matches(Object item) {
+                return item instanceof InvocationTargetException &&
+                       ((InvocationTargetException) item).getCause() instanceof IOException &&
+                       "Whoops".equals(((InvocationTargetException) item).getCause().getMessage());
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Exception checked");
+            }
+        });
+
+        new ScannerWsClientWrapper(scannerWsClient).call(mock(WsRequest.class));
+    }
+
+
+    @Test
+    public void testNonInvocationExceptionWrapped() {
+        expectedException.expectMessage(IsEqual.equalTo("Could not execute ScannerWsClient"));
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectCause(new BaseMatcher<Throwable>() {
+            @Override
+            public boolean matches(Object item) {
+                return item instanceof NoSuchMethodException &&
+                       "java.lang.Object.call(org.sonarqube.ws.client.WsRequest)"
+                               .equals(((NoSuchMethodException) item).getMessage());
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("NoSuchMethodException");
+            }
+        });
+
+        Object scannerWsClient = new Object();
+        new ScannerWsClientWrapper(scannerWsClient).call(mock(WsRequest.class));
+    }
+}


### PR DESCRIPTION
Replaces references to the removed `ScannerUtils` class with Java's `URLEncoder`, and adds implementations of new methods introduced into SonarQube 8.0's interfaces. Since SonarQube 8.0 also changed `ScannerWsClient` from a class to an interface, the `ScannerWsClient` is now invoked through reflection in `ScannerWsClientWrapper` to prevent a `java.lang.IncompatibleClassChangeError` being thrown during invocation.

On top of this, SonarQube Compute Engine now contains a Java Security Manager that blocks access to retrieving `ClassLoader`s, so prevents the work-around used to access the branch API classes required for this plugin to execute. Moving the loading of the impacted classes into a `CoreExtension` and bypassing the class-loading manipulation for these classes overcomes this problem. This will require users of this plugin to install the plugin to both the plugins directory and the core platform's `lib/common` directory (or symlink the files) given plugin classes are only searched for from the plugins directory, and extensions are only loaded from the `common` directory.